### PR TITLE
Fixed bug where the plugin associates permissions with the wrong users

### DIFF
--- a/src/main/java/me/lokka30/commanddefender/listeners/CommandListeners.java
+++ b/src/main/java/me/lokka30/commanddefender/listeners/CommandListeners.java
@@ -33,6 +33,8 @@ public class CommandListeners implements Listener {
     public void onCommand(final PlayerCommandPreprocessEvent event) {
         final String command = event.getMessage();
 
+        instance.commandManager.load();
+
         final CommandManager.BlockedStatus blockedStatus = instance.commandManager.getBlockedStatus(event.getPlayer(), command.split(" "));
 
         if (blockedStatus.isBlocked) {


### PR DESCRIPTION
This change fixes an error where the plugin would treat every online player the same when one of them has the permission to bypass a set of commands that are on "deny", aswell as a bug where the plugin wouldn't correctly catch when the player lost said value.