### PR TITLE
Fixed bug with permission association

### DIFF
--- a/src/main/java/me/lokka30/commanddefender/listeners/CommandListeners.java
+++ b/src/main/java/me/lokka30/commanddefender/listeners/CommandListeners.java
@@ -32,6 +32,7 @@ public class CommandListeners implements Listener {
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onCommand(final PlayerCommandPreprocessEvent event) {
         final String command = event.getMessage();
+        instance.commandManager.load();
 
         final CommandManager.BlockedStatus blockedStatus = instance.commandManager.getBlockedStatus(event.getPlayer(), command.split(" "));
 


### PR DESCRIPTION
This fixes a bug with the plugin, where if one player is able to bypass a command set with the appropriate permission, every only player is able to as well.
It also fixes a bug that would make the plugin aware of added but not removed permissions.