### PR TITLE
Fix false caching

### DIFF
--- a/src/main/java/me/lokka30/commanddefender/managers/CommandManager.java
+++ b/src/main/java/me/lokka30/commanddefender/managers/CommandManager.java
@@ -125,6 +125,7 @@ public class CommandManager {
         // Go in reverse so that a higher 'priority' actually has a higher priority.
         for (int priority = prioritisedListMap.size(); priority > 0; priority--) {
 
+            final String listModeStr = instance.settingsFile.getConfig().getString("priorities." + priority + ".mode");
             PrioritisedList prioritisedList = prioritisedListMap.get(priority);
             final List<String> blockMessage = prioritisedList.denyMessage;
 
@@ -132,9 +133,20 @@ public class CommandManager {
                 prioritisedList.listMode = defaultListMode;
             }
 
-            // Check for permissions that override the list mode in the setting.
-            if (player.hasPermission("commanddefender.allow." + priority)) prioritisedList.listMode = ListMode.ALLOW;
-            if (player.hasPermission("commanddefender.deny." + priority)) prioritisedList.listMode = ListMode.DENY;
+            // Check for permissions that override the list mode in the setting and make sure to re-cache modes depending on currently cached mode. 
+            if (player.hasPermission("commanddefender.allow." + priority)) {
+            	prioritisedList.listMode = ListMode.ALLOW;
+
+            } else if (prioritisedList.listMode == ListMode.ALLOW) {
+            	prioritisedList.listMode = ListMode.fromString(listModeStr);
+            }
+
+            if (player.hasPermission("commanddefender.deny." + priority)) {
+            	prioritisedList.listMode = ListMode.DENY;
+
+            } else if (prioritisedList.listMode == ListMode.DENY) {
+            	prioritisedList.listMode = ListMode.fromString(listModeStr);
+            }
 
             // For each listed command in the prioritised list,
             for (String[] listedCommand : prioritisedList.listedCommands) {

--- a/src/main/java/me/lokka30/commanddefender/managers/CommandManager.java
+++ b/src/main/java/me/lokka30/commanddefender/managers/CommandManager.java
@@ -134,19 +134,10 @@ public class CommandManager {
             }
 
             // Check for permissions that override the list mode in the setting and make sure to re-cache modes depending on currently cached mode. 
-            if (player.hasPermission("commanddefender.allow." + priority)) {
-            	prioritisedList.listMode = ListMode.ALLOW;
-
-            } else if (prioritisedList.listMode == ListMode.ALLOW) {
-            	prioritisedList.listMode = ListMode.fromString(listModeStr);
-            }
-
-            if (player.hasPermission("commanddefender.deny." + priority)) {
-            	prioritisedList.listMode = ListMode.DENY;
-
-            } else if (prioritisedList.listMode == ListMode.DENY) {
-            	prioritisedList.listMode = ListMode.fromString(listModeStr);
-            }
+            if (player.hasPermission("commanddefender.allow." + priority)) { prioritisedList.listMode = ListMode.ALLOW;
+            } else if (prioritisedList.listMode == ListMode.ALLOW) { prioritisedList.listMode = ListMode.fromString(listModeStr); }
+            if (player.hasPermission("commanddefender.deny." + priority)) { prioritisedList.listMode = ListMode.DENY;
+            } else if (prioritisedList.listMode == ListMode.DENY) { prioritisedList.listMode = ListMode.fromString(listModeStr); }
 
             // For each listed command in the prioritised list,
             for (String[] listedCommand : prioritisedList.listedCommands) {


### PR DESCRIPTION
This fixes critical issue where CommandDefender literally breaks after player gets `allow`/`deny` permission and it's revoked from him later.
(Maybe there is no need for `else if` but only `else` but I am not sure)